### PR TITLE
Add pluginmanagement tag to pom.xml to resolve maven errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     </pluginRepositories>
 
     <build>
+    	<pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -213,6 +214,7 @@
                 </configuration>
             </plugin>
         </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>


### PR DESCRIPTION
The pluginManagement tag is required in pom.xml so it compiles fine - Eclipse is reporting errors on pom.xml without this tag